### PR TITLE
Fix venv scripts' #! path

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,34 @@ From the host machine:
     
 On the guest build VM:
 
-    /opt/kinto_rpm/bin/build/buildrpm.sh
+    sudo /home/vagrant/kinto_rpm/bin/build/buildrpm.sh
+        
+Testing a Build
+===============
+Copy the package from the host to the test VM:
+
+    vagrant scp RPMS/x86_64/kinto-4.1.1-1.el7.centos.x86_64.rpm test:/home/vagrant
+    
+SSH into the test VM:
+
+    vagrant ssh test
+    
+Install the package on the test VM:
+
+    sudo yum -y install kinto-4.1.1-1.el7.centos.x86_64.rpm
+    
+Quickie test:
+
+    /opt/kinto/bin/kinto init --backend memory
+    /opt/kinto/bin/kinto start
+    curl http://localhost:8888/v1/
     
 How to Update to a New Version of Kinto
 =======================================
 1. Replace the source tarball
 2. Update `kinto.spec`'s `Version` tag to reflect the source version number
 3. Update the Python packages if applicable (see _A Note..._ below)
-3. Ensure the version of zope.sqlalchemy in the build's `pip install` command matches that in Kinto's `requirements.txt`
-   and that `sqlalchemy-postgresql-json`'s version is appropriate.
+3. Ensure that `sqlalchemy-postgresql-json`'s version in the build's `pip install` command is appropriate.
    
 A Note About Choosing the Python Version
 ========================================

--- a/SPECS/kinto.spec
+++ b/SPECS/kinto.spec
@@ -31,7 +31,13 @@ Kinto
 
 %prep
 %setup -q
-%{__python35u} -m venv --clear %{_builddir}/venv
+
+# Because venv uses the path used to create the virtual environment in the #! line of the scripts it installs in its bin
+# directory, we symlink /opt/kinto, which we want used in the #! lines as it will be valid on install target machines,
+# to %{_builddir}/venv, which is only valid on the build machine.
+ln -fs /opt/kinto %{_builddir}/venv
+%{__python35u} -m venv --clear /opt/kinto
+
 %{_builddir}/venv/bin/pip install --upgrade pip setuptools wheel
 
 
@@ -42,8 +48,9 @@ Kinto
 %{_builddir}/venv/bin/pip install \
   --constraint=%{_builddir}/%{name}-%{version}/requirements.txt \
   %{_builddir}/%{name}-%{version} \
+  raven \
   sqlalchemy-postgresql-json==0.4.7 \
-  zope.sqlalchemy==0.7.7
+  zope.sqlalchemy
 
 %{_builddir}/venv/bin/kinto init --backend=postgresql
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,16 +4,17 @@
 Vagrant.configure('2') do |config|
   config.vm.box = 'centos/7'
 
-  # I was unable to successfully change the default synced folder's provider to vboxsf for bi-directional syncing, so I
-  # disabled it and configured a separate folder.
-  config.vm.synced_folder '.', '/vagrant', disabled: true
-  config.vm.synced_folder '.', '/opt/kinto_rpm', provider: :vboxsf
-
   config.vm.define 'build', primary: true do |build|
     build.vm.provision 'shell', path: 'bin/build/provision.sh'
+
+    # I was unable to successfully change the default synced folder's provider to vboxsf for bi-directional syncing, so
+    # I disabled it and configured a separate folder.
+    build.vm.synced_folder '.', '/vagrant', disabled: true
+    build.vm.synced_folder '.', '/home/vagrant/kinto_rpm', provider: :vboxsf
   end
 
   config.vm.define 'test', autostart: false do |test|
     test.vm.provision 'shell', path: 'bin/test/provision.sh'
+    test.vm.synced_folder '.', '/vagrant', disabled: true
   end
 end

--- a/bin/build/buildrpm.sh
+++ b/bin/build/buildrpm.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -evx
 
-kinto_rpm_dir="/opt/kinto_rpm"
-rpmbuild -bb --define="_topdir ${kinto_rpm_dir}" "${kinto_rpm_dir}/SPECS/kinto.spec"
+project_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+rpmbuild -bb --define="_topdir ${project_dir}" "${project_dir}/SPECS/kinto.spec"

--- a/bin/buildrpm.sh
+++ b/bin/buildrpm.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 set -evx
-vagrant ssh -c "/opt/kinto_rpm/bin/build/buildrpm.sh"
+
+vagrant ssh -c 'sudo ${HOME}/kinto_rpm/bin/build/buildrpm.sh'

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 set -evx
+
 brew tap caskroom/cask
 brew cask install vagrant virtualbox
 set +e
 vagrant box add --provider virtualbox centos/7
 set -e
-vagrant plugin install vagrant-vbguest
+vagrant plugin install \
+  vagrant-scp \
+  vagrant-vbguest
 vagrant up


### PR DESCRIPTION
* Because the build and test VMs were sharing /opt/kinto_rpm, I didn't notice the fact that the venv script's #! lines read /opt/kinto_rpm/BUILD/venv/bin/python3.5
* The upshot is rpmbuild must be run as root in order to create the /opt/kinto symlink for the build
* Added raven package to support Kinto installs that configure this option
* Updated bin/build/buildrpm.sh to be more portable
* Updated the test VM to no longer share /opt/kinto_rpm in order to avoid testing issues ;)